### PR TITLE
Request/Feat: Sanitize string id keys before find, update, and delete actions

### DIFF
--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -60,7 +60,7 @@ defmodule EctoShorts.Actions do
       iex> schema.first_name === user.first_name
       true
   """
-  def find(query, params) do
+  def find(query, %{id: id} = params) when is_integer(id) do
     repo_query = query |> CommonFilters.convert_params_to_filter(params) |> Ecto.Query.first
 
     case Repo.call(:one, [repo_query]) do
@@ -71,6 +71,13 @@ defmodule EctoShorts.Actions do
         })}
       schema -> {:ok, schema}
     end
+  end
+
+  @spec find(queryable :: query, params :: filter_params) :: schema_res
+  def find(query, %{id: id} = params) when is_binary(id) do
+    int_id = String.to_integer(id)
+    new_params = Map.put(params, :id, int_id)
+    find(query, new_params)
   end
 
   @spec create(schema :: Ecto.Schema.t, params :: filter_params) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
@@ -95,7 +102,6 @@ defmodule EctoShorts.Actions do
       create(schema, params)
     end
   end
-
 
   @spec update(
     schema :: Ecto.Schema.t,
@@ -126,6 +132,16 @@ defmodule EctoShorts.Actions do
         )}
       schema_data -> update(schema, schema_data, updates)
     end
+  end
+
+  @spec update(
+    schema :: Ecto.Schema.t,
+    id :: String.t,
+    updates :: map | Keyword.t
+  ) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  def update(schema, schema_id, updates) when is_binary(schema_id) do
+    int_schema_id = String.to_integer(schema_id)
+    update(schema, int_schema_id, updates)
   end
 
   @spec update(
@@ -200,10 +216,16 @@ defmodule EctoShorts.Actions do
       iex> schema.first_name === user.first_name
       true
   """
-  def delete(schema, id) do
+  def delete(schema, id) when is_integer(id) do
     with {:ok, schema_data} <- find(schema, %{id: id}) do
       Repo.call(:delete, [schema_data])
     end
+  end
+
+  @spec delete(schema :: Ecto.Schema.t, id :: String.t) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  def delete(schema, id) when is_binary(id) do
+    int_id = String.to_integer(id)
+    delete(schema, int_id)
   end
 
   @spec stream(queryable :: query, params :: filter_params) :: Enum.t


### PR DESCRIPTION
I'm requesting we add a fallback to sanitize string ID keys before the find, update, and delete actions.

- It removes overhead from a common use case where the data is sent from a controller to the EctoShorts.Actions making it easier to use out of the box

- In the event the 'ID' is not the correct type the wrong EctoShorts.Actions action function will be called. The error message it outputs due to this doesn't make it clear this is why it fails. Eg: Here the changeset function was expecting a schema and instead got passed the ID as a string because currently `EctoShorts.Actions .update()` for eg only handles ints, and lists and therefore tried applying an update call with the wrong params.
![ss](https://user-images.githubusercontent.com/87607684/127753846-3e794d68-6e65-4753-b089-62673966cc5e.jpg)
This catches those fall through cases and makes it clear the type of 'ID' trying to be inserted into a table must explicitly match the type of 'ID' in the table which is of type INT/integer