### PR TITLE
Switches default_opts check from compile to run-time

### DIFF
--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -9,8 +9,8 @@ defmodule EctoShorts.Actions do
   @type schema_list :: list(Ecto.Schema.t) | []
   @type schema_res :: {:ok, Ecto.Schema.t} | {:error, String.t}
 
-  alias EctoShorts.{CommonFilters, Actions.Error, Config}
-  @default_opts [repo: Config.get_default_repo()]
+  import EctoShorts.Config
+  alias EctoShorts.{CommonFilters, Actions.Error}
 
   @doc """
   Gets a schema from the database
@@ -40,7 +40,7 @@ defmodule EctoShorts.Actions do
   """
   @spec all(queryable :: query) :: schema_list
   def all(query) do
-    all(query, @default_opts)
+    all(query, get_default_opts())
   end
 
   @doc """
@@ -62,18 +62,20 @@ defmodule EctoShorts.Actions do
   """
   @spec all(queryable :: query, params :: filter_params) :: schema_list
   def all(query, params) when is_map(params) do
-    all(query, params, @default_opts)
+    all(query, params, get_default_opts())
   end
 
   @spec all(queryable :: query, opts :: Keyword.t) :: schema_list
   def all(query, opts) do
+    default_opts = get_default_opts()
+
     opts
     |> Keyword.take([:repo, :replica])
     |> Enum.empty?()
     |> case do
-      true -> all(query, opts, @default_opts)
+      true -> all(query, opts, default_opts)
       false ->
-        opts = Keyword.merge(@default_opts, opts)
+        opts = Keyword.merge(default_opts, opts)
         all(query, %{}, opts)
     end
   end
@@ -332,10 +334,10 @@ defmodule EctoShorts.Actions do
       true
   """
   def delete(%_{} = schema_data) do
-    delete(schema_data, @default_opts)
+    delete(schema_data, get_default_opts())
   end
   def delete(schema_data) when is_list(schema_data) do
-    delete(schema_data, @default_opts)
+    delete(schema_data, get_default_opts())
   end
 
   @doc """
@@ -371,7 +373,7 @@ defmodule EctoShorts.Actions do
 
   @spec delete(schema :: Ecto.Schema.t, id :: integer) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
   def delete(schema, id) when is_atom(schema) and (is_binary(id) or is_integer(id)) do
-    delete(schema, id, @default_opts)
+    delete(schema, id, get_default_opts())
   end
   @doc """
   Deletes a schema. Can also accept a keyword options list.
@@ -518,7 +520,7 @@ defmodule EctoShorts.Actions do
   end
 
   defp repo(opts) do
-    @default_opts
+    get_default_opts()
     |> Keyword.merge(opts)
     |> Keyword.get(:repo, nil)
   end

--- a/lib/common_changes.ex
+++ b/lib/common_changes.ex
@@ -11,9 +11,9 @@ defmodule EctoShorts.CommonChanges do
     cast_assoc: 3
   ]
 
-  alias EctoShorts.{Actions, SchemaHelpers, Config}
+  import EctoShorts.Config
+  alias EctoShorts.{Actions, SchemaHelpers}
   alias Ecto.Changeset
-  @default_opts [repo: Config.get_default_repo()]
 
   @doc "Run's changeset function if when function returns true"
   @spec put_when(
@@ -81,7 +81,7 @@ defmodule EctoShorts.CommonChanges do
   end
 
   def preload_changeset_assoc(changeset, key, opts) do
-    opts = Keyword.merge(@default_opts, opts)
+    opts = Keyword.merge(get_default_opts(), opts)
     Map.update!(changeset, :data, &opts[:repo].preload(&1, key, opts))
   end
 

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -1,7 +1,9 @@
 defmodule EctoShorts.Config do
   @app :ecto_shorts
 
-  def get_default_repo do
-    Application.get_env(@app, :repo)
+  def get_default_opts do
+    [
+      repo: Application.get_env(@app, :repo)
+    ]
   end
 end


### PR DESCRIPTION
Hey @MikaAK , here's the fix you proposed for the problem I ran into. I moved evaluation of `default_opts` from a module attribute into a function in the Config module.

Here's a quick recap of the issue, which happens when you install and compile the library as a dependency before configuring a `:default_repo` per the install guide. Even after setting the config, Ecto Shorts can still fail to detect the configured repo if it hasn't been recompiled, and this doesn't happen by default it seems.

```
Interactive Elixir (1.12.3) - press Ctrl+C to exit (type h() ENTER for help)
iex(1)> EctoShorts.Actions.all App.Schema 
** (ArgumentError) ecto shorts must be configured with a repo. For further guidence consult the docs. https://hexdocs.pm/ecto_shorts/EctoShorts.html#module-config
    (ecto_shorts 1.0.0) lib/actions.ex:516: EctoShorts.Actions.replica!/1
    (ecto_shorts 1.0.0) lib/actions.ex:97: EctoShorts.Actions.all/3
iex(1)> Application.get_env :ecto_shorts, :repo
App.Repo
```

`mix deps.compile --force` can resolve this situation.