### PR TITLE
fix(order_by): added order_by to the list of acceptable filters

### DIFF
--- a/lib/common_filters.ex
+++ b/lib/common_filters.ex
@@ -15,6 +15,7 @@ defmodule EctoShorts.CommonFilters do
   - `last` - Gets the last n items
   - `limit` - Gets the first n items
   - `offset` - Offsets limit by n items
+  - `order_by` - orders the results in desc or asc order
   - `search` - ***Warning:*** This requires schemas using this to have a `&by_search(query, val)` function
 
   You are also able to filter on any natural field of a model, as well as use

--- a/lib/query_builder/common.ex
+++ b/lib/query_builder/common.ex
@@ -25,7 +25,8 @@ defmodule EctoShorts.QueryBuilder.Common do
     :last,
     :limit,
     :offset,
-    :search
+    :search,
+    :order_by
   ]
 
   @spec filters :: list(atom)


### PR DESCRIPTION
not having the atom in that list prevents `order_by` being added to queries. 