### PR TITLE
chore: add support for equal/not_equal operator on value types.

### DIFF
--- a/lib/common_filters.ex
+++ b/lib/common_filters.ex
@@ -30,6 +30,8 @@ defmodule EctoShorts.CommonFilters do
   CommonFilters.convert_params_to_filter(User, %{name: %{age: %{gte: 18, lte: 30}}})
   CommonFilters.convert_params_to_filter(User, %{name: %{is_banned: %{!=: nil}}})
   CommonFilters.convert_params_to_filter(User, %{name: %{is_banned: %{==: nil}}})
+  CommonFilters.convert_params_to_filter(User, %{name: %{balance: %{!=: 0}}})
+  CommonFilters.convert_params_to_filter(User, %{name: %{balance: %{==: 0}}})
   CommonFilters.convert_params_to_filter(User, %{name: "Billy"})
   ```
   """

--- a/lib/common_filters.ex
+++ b/lib/common_filters.ex
@@ -31,7 +31,6 @@ defmodule EctoShorts.CommonFilters do
   CommonFilters.convert_params_to_filter(User, %{name: %{is_banned: %{!=: nil}}})
   CommonFilters.convert_params_to_filter(User, %{name: %{is_banned: %{==: nil}}})
   CommonFilters.convert_params_to_filter(User, %{name: %{balance: %{!=: 0}}})
-  CommonFilters.convert_params_to_filter(User, %{name: %{balance: %{==: 0}}})
   CommonFilters.convert_params_to_filter(User, %{name: "Billy"})
   ```
   """

--- a/lib/query_builder/schema/comparison_filter.ex
+++ b/lib/query_builder/schema/comparison_filter.ex
@@ -38,8 +38,16 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     where(query, [scm], is_nil(field(scm, ^filter_field)))
   end
 
+  defp build_subfield_filter(query, filter_field, :==, val) do
+    where(query, [scm], field(scm, ^filter_field) == ^val)
+  end
+
   defp build_subfield_filter(query, filter_field, :!=, nil) do
     where(query, [scm], not is_nil(field(scm, ^filter_field)))
+  end
+
+  defp build_subfield_filter(query, filter_field, :!=, val) do
+    where(query, [scm], field(scm, ^filter_field) != ^val)
   end
 
   defp build_subfield_filter(query, filter_field, :gt, val) do

--- a/lib/query_builder/schema/comparison_filter.ex
+++ b/lib/query_builder/schema/comparison_filter.ex
@@ -38,10 +38,6 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     where(query, [scm], is_nil(field(scm, ^filter_field)))
   end
 
-  defp build_subfield_filter(query, filter_field, :==, val) do
-    where(query, [scm], field(scm, ^filter_field) == ^val)
-  end
-
   defp build_subfield_filter(query, filter_field, :!=, nil) do
     where(query, [scm], not is_nil(field(scm, ^filter_field)))
   end


### PR DESCRIPTION
This small tweak will allow us to produce SQL queries like: `balance <> 0`
Based on my usage of the library, `EctoShorts` does support the "not equal" operator but only for `null/not null` checks.