### PR TITLE
Build array filter

### DIFF
--- a/lib/query_builder/schema.ex
+++ b/lib/query_builder/schema.ex
@@ -25,7 +25,12 @@ defmodule EctoShorts.QueryBuilder.Schema do
   def create_schema_filter({filter_field, val}, schema, query) do
     cond do
       filter_field in schema.__schema__(:query_fields) ->
-        ComparisonFilter.build(query, schema.__schema__(:field_source, filter_field), val)
+        case schema.__schema__(:type, filter_field) do
+          {:array, _} ->
+            ComparisonFilter.build_array(query, schema.__schema__(:field_source, filter_field), val)
+          _ ->
+            ComparisonFilter.build(query, schema.__schema__(:field_source, filter_field), val)
+        end
 
       filter_field in schema.__schema__(:associations) ->
         binding_alias = :"ecto_shorts_#{filter_field}"

--- a/lib/query_builder/schema/comparison_filter.ex
+++ b/lib/query_builder/schema/comparison_filter.ex
@@ -34,6 +34,10 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     where(query, [scm], field(scm, ^filter_field) == ^val)
   end
 
+  def build_array(query, filter_field, val) when is_list(val) do
+    where(query, [scm], field(scm, ^filter_field) == ^val)
+  end
+
   def build_array(query, filter_field, filters) when is_map(filters) do
     build(query, filter_field, filters)
   end

--- a/lib/query_builder/schema/comparison_filter.ex
+++ b/lib/query_builder/schema/comparison_filter.ex
@@ -34,6 +34,10 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     where(query, [scm], field(scm, ^filter_field) == ^val)
   end
 
+  def build_array(query, filter_field, val) do
+    where(query, [scm], ^val in field(scm, ^filter_field))
+  end
+
   defp build_subfield_filter(query, filter_field, :==, nil) do
     where(query, [scm], is_nil(field(scm, ^filter_field)))
   end

--- a/lib/query_builder/schema/comparison_filter.ex
+++ b/lib/query_builder/schema/comparison_filter.ex
@@ -34,6 +34,10 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     where(query, [scm], field(scm, ^filter_field) == ^val)
   end
 
+  def build_array(query, filter_field, filters) when is_map(filters) do
+    build(query, filter_field, filters)
+  end
+
   def build_array(query, filter_field, val) do
     where(query, [scm], ^val in field(scm, ^filter_field))
   end


### PR DESCRIPTION
Changes to query builder to handle an array field in a schema. 

Currently EctoShorts handles conversions the following way when dealing with an array field
`CommonFilters.convert_params_to_filter(User, %{array_field: :value})` =>
`from u0 in Schemas.User,
  where: u0.array_field == ^:value,
  select: u0`

`CommonFilters.convert_params_to_filter(User, %{array_field: [:value]})` =>
`from u0 in Schemas.User,
  where: u0.array_field in ^[:value],
  select: u0`

Both of which error out

Now EctoShorts will do the following conversions

`CommonFilters.convert_params_to_filter(User, %{array_field: :value})` =>
`from u0 in Schemas.User,
  where: ^:value in u0.array_field,
  select: u0`
  
 `CommonFilters.convert_params_to_filter(User, %{array_field: [:value]})` =>
`from u0 in Schemas.User,
  where: u0.array_field == ^[:value],
  select: u0`
