### PR TITLE
remove Ecto.Schema.t as option for first argument in Actions.create

### DIFF
--- a/.dialyzer-ignore.exs
+++ b/.dialyzer-ignore.exs
@@ -1,6 +1,4 @@
 [
-  ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function create.|,
-  ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function create.|,
   ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_or_create.|,
   ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_or_create.|,
   ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_and_update.|,

--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -167,8 +167,8 @@ defmodule EctoShorts.Actions do
       iex> schema.first_name
       true
   """
-  @spec create(schema :: Ecto.Schema.t, params :: filter_params, opts) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
-  @spec create(schema :: Ecto.Schema.t, params :: filter_params) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  @spec create(schema :: module(), params :: filter_params, opts) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  @spec create(schema :: module(), params :: filter_params) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
   def create(schema, params, opts \\ []) do
     repo!(opts).insert(create_changeset(params, schema), opts)
   end


### PR DESCRIPTION
This is the fix for those two dialyzer errors:
```elixir
lib/actions.ex:173:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
EctoShorts.Actions.create/3

Success typing:
@spec create(atom(), _, Keyword.t()) :: any()

lib/actions.ex:174:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
EctoShorts.Actions.create/2

Success typing:
@spec create(atom(), _) :: any()
```

Explanation:
Actions.create calls Actions.create_changeset/2, which in turn calls function_exported?/3 and that one only takes a module as the first argument.