### PR TITLE
fix typespecs for find_or_create

### DIFF
--- a/.dialyzer-ignore.exs
+++ b/.dialyzer-ignore.exs
@@ -1,6 +1,4 @@
 [
-  ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_or_create.|,
-  ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_or_create.|,
   ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_and_update.|,
   ~r|lib/actions.ex:.*:invalid_contract Invalid type specification for function find_and_upsert.|,
   ~r|lib/actions.ex:.*:call The function call delete will not succeed.|,

--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -188,8 +188,8 @@ defmodule EctoShorts.Actions do
 
       iex> {:ok, schema} = EctoSchemas.Actions.find_or_create(EctoSchemas.Accounts.User, %{name: "great name"}, repo: MyApp.MyRepoModule.Repo, replica: MyApp.MyRepoModule.Repo.replica())
   """
-  @spec find_or_create(Ecto.Schema.t, map, opts) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
-  @spec find_or_create(Ecto.Schema.t, map) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  @spec find_or_create(query(), map, opts) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
+  @spec find_or_create(query(), map) :: {:ok, Ecto.Schema.t} | {:error, Ecto.Changeset.t}
   def find_or_create(schema, params, opts \\ []) do
     find_params = Map.drop(params, schema.__schema__(:associations))
 


### PR DESCRIPTION
This fixes those two dialyzer complaints:
```
lib/actions.ex:191:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
EctoShorts.Actions.find_or_create/3

Success typing:
@spec find_or_create(Ecto.Query | Ecto.Schema, map(), Keyword.t()) :: {:error, _} | {:ok, %{atom() => _}}

\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
lib/actions.ex:192:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
EctoShorts.Actions.find_or_create/2

Success typing:
@spec find_or_create(Ecto.Query | Ecto.Schema, map()) :: {:error, _} | {:ok, %{atom() => _}}

```