### PR TITLE
fix commonchanges typespecs

### DIFF
--- a/.dialyzer-ignore.exs
+++ b/.dialyzer-ignore.exs
@@ -1,4 +1,3 @@
 [
-  ~r|lib/common_changes.ex:.*:exact_eq The test maybe_improper_list()|,
-  ~r|lib/common_changes.ex:.*:call The function call preload_changeset_assoc will not succeed.|,
+
   ]

--- a/lib/common_changes.ex
+++ b/lib/common_changes.ex
@@ -51,7 +51,7 @@ defmodule EctoShorts.CommonChanges do
     iex> CommonChanges.preload_change_assoc(changeset, :my_relation, repo: MyApp.OtherRepo)
     iex> CommonChanges.preload_change_assoc(changeset, :my_relation, required: true)
   """
-  @spec preload_change_assoc(Changeset.t, atom, Keyword.t) :: Changeset.t
+  @spec preload_change_assoc(Changeset.t, atom, keyword()) :: Changeset.t
   @spec preload_change_assoc(Changeset.t, atom) :: Changeset.t
   def preload_change_assoc(changeset, key, opts) do
     if Map.has_key?(changeset.params, Atom.to_string(key)) do
@@ -75,7 +75,7 @@ defmodule EctoShorts.CommonChanges do
 
   @doc "Preloads a changesets association"
   @spec preload_changeset_assoc(Changeset.t, atom) :: Changeset.t
-  @spec preload_changeset_assoc(Changeset.t, atom, list(integer)) :: Changeset.t
+  @spec preload_changeset_assoc(Changeset.t, atom, keyword()) :: Changeset.t
   def preload_changeset_assoc(changeset, key, opts \\ [])
 
   def preload_changeset_assoc(changeset, key, opts) do
@@ -105,8 +105,6 @@ defmodule EctoShorts.CommonChanges do
     end
   end
 
-  @spec put_or_cast_assoc(Changeset.t, atom) :: Changeset.t
-  @spec put_or_cast_assoc(Changeset.t, atom, Keyword.t) :: Changeset.t
   @doc """
   Determines put or cast on association with some special magic
 
@@ -119,15 +117,20 @@ defmodule EctoShorts.CommonChanges do
   CommonChanges.put_or_cast_assoc(change(user, fruits: [%{id: 1}, %{id: 3}]), :fruits)
   ```
   """
+  @spec put_or_cast_assoc(Changeset.t, atom) :: Changeset.t
+  @spec put_or_cast_assoc(Changeset.t, atom, Keyword.t) :: Changeset.t
   def put_or_cast_assoc(changeset, key, opts \\ []) do
     params_data = Map.get(changeset.params, Atom.to_string(key))
 
     find_method_and_put_or_cast(changeset, key, params_data, opts)
   end
 
+  defp find_method_and_put_or_cast(changeset, key, params_data, opts) when params_data === nil do
+    cast_assoc(changeset, key, opts)
+  end
+
   defp find_method_and_put_or_cast(changeset, key, params_data, opts) when is_list(params_data) do
     cond do
-      is_nil(params_data) -> cast_assoc(changeset, key, opts)
 
       SchemaHelpers.all_schemas?(params_data) -> put_assoc(
         changeset,

--- a/lib/common_changes.ex
+++ b/lib/common_changes.ex
@@ -125,7 +125,7 @@ defmodule EctoShorts.CommonChanges do
     find_method_and_put_or_cast(changeset, key, params_data, opts)
   end
 
-  defp find_method_and_put_or_cast(changeset, key, params_data, opts) when params_data === nil do
+  defp find_method_and_put_or_cast(changeset, key, nil, opts) do
     cast_assoc(changeset, key, opts)
   end
 


### PR DESCRIPTION
This is the fix for those two
```
lib/common_changes.ex:130:exact_eq
The test maybe_improper_list() == nil can never evaluate to 'true'.
________________________________________________________________________________
lib/common_changes.ex:149:call
The function call will not succeed.

EctoShorts.CommonChanges.preload_changeset_assoc(_changeset :: atom() | %{:params => _, _ => _}, _key :: atom(), [{atom(), _}, ...])

breaks the contract
(Ecto.Changeset.t(), atom(), [integer()]) :: Ecto.Changeset.t()
```