### PR TITLE
feat: enables users to add custom query filters

### DIFF
--- a/lib/common_filters.ex
+++ b/lib/common_filters.ex
@@ -77,7 +77,8 @@ defmodule EctoShorts.CommonFilters do
   end
 
   def create_schema_filter({filter, val}, query) do
-    QueryBuilder.create_schema_filter(QueryBuilder.Schema, {filter, val}, query)
+    builder = if filter in QueryBuilder.Custom.filters(), do: QueryBuilder.Custom, else: QueryBuilder.Schema
+    builder.create_schema_filter({filter, val}, query)
   end
 
   defp ensure_last_is_final_filter(params) do

--- a/lib/query_builder/custom.ex
+++ b/lib/query_builder/custom.ex
@@ -1,0 +1,37 @@
+defmodule EctoShorts.QueryBuilder.Custom do
+  @moduledoc """
+  This module enables the addition of custom query filters
+  to the query builder through a custom module defined
+  in the configuration of the dependent application.
+  """
+
+  @type filter_tuple :: {filter_type :: atom, value :: any}
+  @type accumulator_query :: Ecto.Query.t
+
+  @behaviour EctoShorts.QueryBuilder
+
+  @impl EctoShorts.QueryBuilder
+  @spec create_schema_filter(filter_tuple(), accumulator_query()) :: accumulator_query()
+  def create_schema_filter(filter_tuple, accumulator_query),
+    do: apply(custom_module(), :create_custom_schema_filter, [filter_tuple, accumulator_query])
+
+  @doc "Adds to the accumulator query with filter_type and value"
+  @callback create_custom_schema_filter(filter_tuple, accumulator_query) :: accumulator_query
+
+  @spec create_custom_schema_filter(filter_tuple, accumulator_query) :: accumulator_query
+  def create_custom_schema_filter(_filter_tuple, accumulator_query),
+    do: accumulator_query
+
+  def filters, do: apply(custom_module(), :custom_filters, [])
+
+  @doc "List of custom filters"
+  @callback custom_filters() :: list(atom)
+
+  @spec custom_filters() :: list(atom)
+  def custom_filters, do: []
+
+  @spec custom_module() :: module
+  defp custom_module() do
+    Application.get_env(:ecto_shorts, :custom_query_builder_module) || EctoShorts.QueryBuilder.Custom
+  end
+end


### PR DESCRIPTION
## Overview

Added the EctoShorts.QueryBuilder.Custom behavior. This module enables the addition of custom query filters to the query builder through a custom module defined in the configuration of the dependent application.

## Example 

An example of how custom filters can be implemented using the `EctoShorts.QueryBuilder.Custom` behavior.

This module offers the following features:

- Defines custom filters such as `:select_balance_field_only`, `:currency_code`, and `:amount_gte`.
- Implements the `create_custom_schema_filter/2` function to build queries based on custom filter types.

```elixir
  
defmodule MyApp.EctoShorts.QueryBuilder.Custom do
  import Ecto.Query, only: [select: 3, where: 3]

  alias EctoShorts.QueryBuilder.Custom

  @behaviour Custom

  @custom_filters [:select_balance_field_only, :currency_code, :amount_gte]

  @impl Custom
  def custom_filters, do: @custom_filters

  @impl Custom
  def create_custom_schema_filter({:select_balance_field_only, true}, query),
    do: select(query, [b], b.balance)
  def create_custom_schema_filter({:select_balance_field_only, _}, query), do: query

  @impl Custom
  def create_custom_schema_filter({:currency_code, val}, query) do
    where(query, [b], fragment("(?).currency_code = ?", b.balance, ^to_string(val)))
  end

  @impl Custom
  def create_custom_schema_filter({:amount_gte, val}, query) do
    where(query, [b], fragment("(?).amount >= ?", b.balance, ^val))
  end
end

```