### PR TITLE
Ensure schema module is loaded for function_exported.

### DIFF
--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -490,9 +490,7 @@ defmodule EctoShorts.Actions do
   end
 
   defp create_changeset(params, schema) do
-    Code.ensure_loaded(schema)
-
-    if function_exported?(schema, :create_changeset, 1) do
+    if Code.ensure_loaded?(schema) and function_exported?(schema, :create_changeset, 1) do
       schema.create_changeset(params)
     else
       schema.changeset(struct(schema, %{}), params)

--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -490,6 +490,8 @@ defmodule EctoShorts.Actions do
   end
 
   defp create_changeset(params, schema) do
+    Code.ensure_loaded(schema)
+
     if function_exported?(schema, :create_changeset, 1) do
       schema.create_changeset(params)
     else


### PR DESCRIPTION
Ensure schema module is loaded before checking to see if `create_changeset/1` is exported.

`Kernel.function_exported?/3` does NOT load a module in case it is not loaded.

This will, for example, cause tests to fail in some cases, because your module with `create_changeset/1` definde will only be loaded if it has changed and needed to be recompiled.

If this happens then the EctoShorts erranously thinks that the function isn't defined, and tries to fall back to `changeset/2` insted (which might not be defined).

The call to `Code.ensure_loaded?(schema)` will solve this problem if the schema module wasn't loaded, and it'll be a no-op if it's already loaded.