### PR TITLE
has_through_schema_edge_case

### DIFF
--- a/lib/query_builder/schema.ex
+++ b/lib/query_builder/schema.ex
@@ -38,7 +38,19 @@ defmodule EctoShorts.QueryBuilder.Schema do
   end
 
   defp get_associated_schema_from_field(schema, field_key) do
-    schema.__schema__(:association, field_key).queryable
+    association = schema.__schema__(:association, field_key)
+    case association do
+      %Ecto.Association.HasThrough{
+        through: [field1, field2]
+      } ->
+        schema
+        |> get_associated_schema_from_field(field1)
+        |> get_associated_schema_from_field(field2)
+      %{related: related} ->
+        related
+      _ ->
+        raise ArgumentError, message: "#{Atom.to_string(field_key)} does not have an associated schema for #{schema.__schema__(:source)}"
+    end
   end
 
   defp create_schema_query_field_filter(query, schema, filter_field, val) do


### PR DESCRIPTION
Currently there is a bug on main causing the recursive relation schema filters to fail on a has_through association.

The underlying ecto struct for has_through does not have a queryable field which is how the function `get_associated_schema_from_field` determines the schema for the field
https://hexdocs.pm/ecto/Ecto.Association.HasThrough.html

This change pattern matches on `schema.__schema__(:association, field_key)` and determines if it is a has_through association. If it is it will recursively call itself in order to determine the schema for the first field, and then the schema for the second field.

This change also determines the schema based on `:related` instead of `:queryable` as the docs seem to suggest `:related` to be the actual associated schema
https://hexdocs.pm/ecto/Ecto.Association.BelongsTo.html
https://hexdocs.pm/ecto/Ecto.Association.Has.html
https://hexdocs.pm/ecto/Ecto.Association.ManyToMany.html