### PR TITLE
feat: custom filters in schema

### DIFF
--- a/lib/query_builder.ex
+++ b/lib/query_builder.ex
@@ -2,17 +2,20 @@ defmodule EctoShorts.QueryBuilder do
   @moduledoc "Behaviour for query building from filter tuples"
 
   @type filter_tuple :: {filter_type :: atom, value :: any}
-  @type accumulator_query :: Ecto.Query.t
+  @type accumulator_query :: Ecto.Query.t()
 
   @doc "Adds to accumulator query with filter_type and value"
-  @callback create_schema_filter(filter_tuple, accumulator_query) :: Ecto.Query.t
+  @callback create_schema_filter(filter_tuple, accumulator_query) :: Ecto.Query.t()
+  @callback custom_filters() :: list(atom)
 
-  @spec create_schema_filter(module, filter_tuple, accumulator_query) :: Ecto.Query.t
+  @optional_callbacks custom_filters: 0
+
+  @spec create_schema_filter(module, filter_tuple, accumulator_query) :: Ecto.Query.t()
   def create_schema_filter(builder, filter_tuple, query) do
     builder.create_schema_filter(filter_tuple, query)
   end
 
-  @spec query_schema(Ecto.Queryable.t) :: Ecto.Queryable.t()
+  @spec query_schema(Ecto.Queryable.t()) :: Ecto.Queryable.t()
   @doc "Pulls the schema from a query"
   def query_schema(%{from: %{source: {_, schema}}}), do: query_schema(schema)
   def query_schema(%{from: %{query: %{from: {_, schema}}}}), do: schema


### PR DESCRIPTION
 ### Overview

•Implemented support for custom filters at the schema level.

•Introduced a new optional callback custom_filters/0 in EctoShorts.QueryBuilder to allow schemas to define their own custom filters.

•Modified EctoShorts.CommonFilters.create_schema_filter/2 to dynamically check if a schema supports custom filters and applies them if available.

 ### Example Usage

The following example illustrates how to define custom filters for a schema that tracks balances in different currencies:

1.	Migration:

```elixir
defmodule PaySys.Repo.Migrations.CreateMoneyWithCurrencyAndBalances do
  use Ecto.Migration

  def up do
    execute("""
    CREATE TYPE public.money_with_currency AS (
      currency_code varchar,
      amount numeric
    );
    """)

    create table(:balances) do
      add :balance, :money_with_currency
      add :user_id, references(:users, on_delete: :nothing)

      timestamps(type: :utc_datetime_usec)
    end

    create index(:balances, [:user_id])
  end

  def down do
    drop table(:balances)
    execute("DROP TYPE public.money_with_currency;")
  end
end
```

2.	Schema with Custom Filters:

```elixir
defmodule PaySys.Funds.Balance do
  use Ecto.Schema

  import Ecto.Query, only: [where: 3, fragment: 1]

  alias EctoShorts.QueryBuilder

  @behaviour QueryBuilder

  @impl QueryBuilder
  @spec create_schema_filter({atom, any()}, Ecto.Query.t()) :: Ecto.Query.t()
  def create_schema_filter({:currency_code, val}, query) do
    where(query, [b], fragment("(?).currency_code = ?", b.balance, ^to_string(val)))
  end

  def create_schema_filter({:amount_gte, val}, query) do
    where(query, [b], fragment("(?).amount >= ?", b.balance, ^val))
  end

  @impl QueryBuilder
  @spec custom_filters() :: list(atom())
  def custom_filters do
    [:currency_code, :amount_gte]
  end
end
```

3.	Context for Querying:

```elixir
defmodule PaySys.Funds do
  alias EctoShorts.Actions
  alias PaySys.Funds.Balance

  @doc """
  ## Examples

      iex> PaySys.Funds.list_balances(%{currency_code: "USD", amount_gte: 100})
      [%PaySys.Funds.Balance{balance: %Money{currency: :USD, amount: 200}}]

      iex> PaySys.Funds.list_balances(%{currency_code: "EUR", amount_gte: 50})
      [%PaySys.Funds.Balance{balance: %Money{currency: :EUR, amount: 150}}]

      iex> PaySys.Funds.list_balances(%{currency_code: "USD", amount_gte: 1000})
      []
  """
  @spec list_balances(Actions.filter_params()) :: [Balance.t()] | []
  def list_balances(params \\ %{}) do
    Actions.all(Balance, params)
  end
end
```