### PR TITLE
fix: preload_change_assoc

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -2,21 +2,29 @@
 # and its dependencies with the aid of the Mix.Config module.
 import Config
 
+config :ecto_shorts, ecto_repos: [EctoShorts.Support.Repo]
 config :ecto_shorts,
   repo: nil,
   error_module: EctoShorts.Actions.Error
 
 if Mix.env() == :test do
-  config :ecto_shorts, ecto_repos: [EctoShorts.Support.Repo]
   config :ecto_shorts, repo: EctoShorts.Support.Repo
   config :ecto_shorts, :sql_sandbox, true
   config :ecto_shorts, EctoShorts.Support.Repo,
     username: "postgres",
-    database: "ecto_shorts",
+    database: "ecto_shorts_test",
     hostname: "localhost",
     show_sensitive_data_on_connection_error: true,
     log: :debug,
     stacktrace: true,
     pool: Ecto.Adapters.SQL.Sandbox,
     pool_size: 10
+else
+  config :ecto_shorts, EctoShorts.Support.Repo,
+    username: "postgres",
+    database: "ecto_shorts_dev",
+    hostname: "localhost",
+    pool_size: 10,
+    show_sensitive_data_on_connection_error: true,
+    stacktrace: true
 end

--- a/lib/actions.ex
+++ b/lib/actions.ex
@@ -391,7 +391,19 @@ defmodule EctoShorts.Actions do
       iex> schema.first_name === user.first_name
       true
   """
-  @spec delete(schema_data :: Ecto.Schema.t | schema_list() | module(), opts) :: {:ok, Ecto.Schema.t} | {:error, any()}
+  @spec delete(schema_data :: Ecto.Changeset.t() | Ecto.Schema.t | schema_list() | module(), opts) :: {:ok, Ecto.Schema.t} | {:error, any()}
+  def delete(%Ecto.Changeset{} = changeset, opts) do
+    case repo!(opts).delete(changeset, opts) do
+      {:error, changeset} ->
+        {:error, Error.call(
+          :internal_server_error,
+          "Cannot delete record",
+          %{changeset: changeset}
+        )}
+      ok -> ok
+    end
+  end
+
   def delete(%schema{} = schema_data, opts) do
     # The schema data is wrapped in a changeset before delete
     # so that ecto can apply the constraint error to the
@@ -402,7 +414,7 @@ defmodule EctoShorts.Actions do
       {:error, changeset} ->
         {:error, Error.call(
           :internal_server_error,
-          "Error deleting #{inspect(schema)}",
+          "Cannot delete record",
           %{changeset: changeset, schema_data: schema_data}
         )}
       ok -> ok

--- a/lib/common_changes.ex
+++ b/lib/common_changes.ex
@@ -152,7 +152,7 @@ defmodule EctoShorts.CommonChanges do
     changeset
   end
 
-  defp do_preload_change_assoc(changeset, key, %{cardinality: :many}, opts) do
+  defp do_preload_change_assoc(changeset, key, %Ecto.Association.ManyToMany{}, opts) do
     case Map.get(changeset.params, Atom.to_string(key)) do
       nil -> changeset
       params_data ->

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,7 @@ defmodule EctoShorts.MixProject do
     ]
   end
 
+  defp elixirc_paths(:dev), do: ["lib", "test/support"]
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 

--- a/test/support/schemas/user.ex
+++ b/test/support/schemas/user.ex
@@ -8,7 +8,8 @@ defmodule EctoShorts.Support.Schemas.User do
 
     has_many :comments, EctoShorts.Support.Schemas.Comment
 
-    many_to_many :posts, EctoShorts.Support.Schemas.Post, join_through: "users_posts"
+    many_to_many :posts, EctoShorts.Support.Schemas.Post,
+      join_through: EctoShorts.Support.Schemas.UserPost
 
     timestamps()
   end

--- a/test/support/schemas/user_post.ex
+++ b/test/support/schemas/user_post.ex
@@ -1,0 +1,20 @@
+defmodule EctoShorts.Support.Schemas.UserPost do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+
+  schema "users_posts" do
+    belongs_to :post, EctoShorts.Support.Schemas.Post
+    belongs_to :user, EctoShorts.Support.Schemas.User
+
+    timestamps()
+  end
+
+  @available_attributes [:post_id, :user_id]
+
+  def changeset(model_or_changeset, attrs \\ %{}) do
+    cast(model_or_changeset, attrs, @available_attributes)
+  end
+end


### PR DESCRIPTION
When a many_to_many association is given to `EctoShorts.CommonChanges.preload_change_assoc` the association is not added to the changeset's params and/or changes because `Ecto.Changeset.cast_assoc` is being called which does not work with `many_to_many` relationships. This behaviour is [documented](https://hexdocs.pm/ecto/Ecto.Changeset.html#cast_assoc/3).

The function has been updated to check the relationship and uses put_assoc for many_to_many relationships.

### Steps to reproduce

```elixir
iex> Application.ensure_all_started(:postgrex)

iex> EctoShorts.Support.Repo.start_link()

iex> Application.put_env(:ecto_shorts, :repo, EctoShorts.Support.Repo)

iex> {:ok, post} = %EctoShorts.Support.Schemas.Post{} |> EctoShorts.Support.Schemas.Post.changeset() |> EctoShorts.Support.Repo.insert()

iex> {:ok, user} = %EctoShorts.Support.Schemas.User{} |> EctoShorts.Support.Schemas.User.changeset(%{email: "example"}) |> Ecto.Changeset.put_assoc(:posts, [post]) |> EctoShorts.Support.Repo.insert()

# view the current state
iex> EctoShorts.Support.Repo.preload(post, :users)

# users should exist in the params here and it doesn't. The change isn't applied
iex> changeset = post |> EctoShorts.Support.Schemas.Post.changeset(%{}) |> EctoShorts.CommonChanges.preload_change_assoc(:users, [%{id: user.id, email: "updated_email"}])
%{}
```