### PR TITLE
test: abstract schema delete test uses correct constraints

### DIFF
--- a/test/ecto_shorts/actions_abstract_schema_test.exs
+++ b/test/ecto_shorts/actions_abstract_schema_test.exs
@@ -1,6 +1,5 @@
 defmodule EctoShorts.ActionsAbstractSchemaTest do
   @moduledoc false
-  alias EctoShorts.Support.Schemas.UserAvatarNoConstraint
   use EctoShorts.DataCase
 
   alias EctoShorts.Actions

--- a/test/support/schemas/file_info.ex
+++ b/test/support/schemas/file_info.ex
@@ -29,6 +29,7 @@ defmodule EctoShorts.Support.Schemas.FileInfo do
     |> cast(attrs, @available_fields)
     |> unique_constraint(:unique_identifier)
     |> validate_length(:unique_identifier, min: 3)
+    |> foreign_key_constraint(:assoc_id)
   end
 
   # This callback function is invoked by `EctoShorts.CommonFilters.convert_params_to_filter`

--- a/test/support/schemas/user_avatar_no_constraint.ex
+++ b/test/support/schemas/user_avatar_no_constraint.ex
@@ -1,4 +1,4 @@
-defmodule EctoShorts.Support.Schemas.UserAvatar do
+defmodule EctoShorts.Support.Schemas.UserAvatarNoConstraint do
   @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
@@ -20,8 +20,6 @@ defmodule EctoShorts.Support.Schemas.UserAvatar do
   ]
 
   def changeset(model_or_changeset, attrs \\ %{}) do
-    model_or_changeset
-    |> cast(attrs, @available_fields)
-    |> no_assoc_constraint(:file_info, name: "file_info_user_avatars_assoc_id_fkey")
+    cast(model_or_changeset, attrs, @available_fields)
   end
 end


### PR DESCRIPTION
The test for Actions.delete in the abstract schema test is updated on this pr to use the appropriate constraints on the correct schemas. 