### PR TITLE
chore: move repo config logic to `EctoShorts.Config`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,6 +4,7 @@ import Config
 
 config :ecto_shorts,
   repo: nil,
+  replica: nil,
   error_module: EctoShorts.Actions.Error
 
 if Mix.env() === :test do

--- a/lib/ecto_shorts/common_changes.ex
+++ b/lib/ecto_shorts/common_changes.ex
@@ -165,16 +165,14 @@ defmodule EctoShorts.CommonChanges do
   def preload_changeset_assoc(changeset, key, opts \\ [])
 
   def preload_changeset_assoc(changeset, key, opts) do
-    opts = Keyword.merge(default_opts(), opts)
-
     if opts[:ids] do
       schema = changeset_relationship_schema(changeset, key)
 
-      preloaded_data = Actions.all(schema, %{ids: opts[:ids]}, repo: opts[:repo])
+      preloaded_data = Actions.all(schema, %{ids: opts[:ids]}, opts)
 
       Map.update!(changeset, :data, &Map.put(&1, key, preloaded_data))
     else
-      Map.update!(changeset, :data, &opts[:repo].preload(&1, key, opts))
+      Map.update!(changeset, :data, &Config.repo!(opts).preload(&1, key, opts))
     end
   end
 
@@ -263,6 +261,4 @@ defmodule EctoShorts.CommonChanges do
 
   defp relationship_exists?({:assoc, _}), do: true
   defp relationship_exists?(_), do: false
-
-  def default_opts, do: [repo: Config.repo()]
 end

--- a/lib/ecto_shorts/config.ex
+++ b/lib/ecto_shorts/config.ex
@@ -66,7 +66,7 @@ defmodule EctoShorts.Config do
         # config.exs
         import Config
 
-        config :ecto_shorts, :repo, YourApp.Repo.Replica
+        config :ecto_shorts, :repo, YourApp.Repo
         ```
       """
     end
@@ -101,7 +101,7 @@ defmodule EctoShorts.Config do
       * The option `:replica` is specified at runtime.
 
         ```
-        EctoShorts.Actions.all(YourApp.Schema, %{id: [1, 2, 3]}, replica: YourApp.Repo)
+        EctoShorts.Actions.all(YourApp.Schema, %{id: [1, 2, 3]}, replica: YourApp.Repo.Replica)
         ```
 
       * The option `:replica` is set in configuration.
@@ -125,7 +125,7 @@ defmodule EctoShorts.Config do
         # config.exs
         import Config
 
-        config :ecto_shorts, :repo, YourApp.Repo.Replica
+        config :ecto_shorts, :repo, YourApp.Repo
         ```
       """
     end

--- a/lib/ecto_shorts/config.ex
+++ b/lib/ecto_shorts/config.ex
@@ -3,7 +3,91 @@ defmodule EctoShorts.Config do
 
   @app :ecto_shorts
 
+  @doc """
+  Returns the value of `ecto_shorts` config key `:repo`.
+
+  ### Examples
+
+      iex> EctoShorts.Config.repo()
+      EctoShorts.Support.Repo
+  """
+  @spec repo :: Ecto.Repo.t() | nil
   def repo do
     Application.get_env(@app, :repo)
+  end
+
+  @doc """
+  Returns the value of `ecto_shorts` config key `:replica`.
+
+  ### Examples
+
+      iex> EctoShorts.Config.replica()
+      nil
+  """
+  @spec replica :: Ecto.Repo.t() | nil
+  def replica do
+    Application.get_env(@app, :replica)
+  end
+
+  @doc """
+  Returns a `Ecto.Repo` module.
+
+  Raises if the repo is not configured and the option `:repo` is not set.
+
+  ### Examples
+
+      iex> EctoShorts.Config.repo!()
+      EctoShorts.Support.Repo
+
+      iex> EctoShorts.Config.repo!(repo: YourApp.Repo)
+      YourApp.Repo
+  """
+  @spec repo!(keyword()) :: Ecto.Repo.t()
+  @spec repo! :: Ecto.Repo.t()
+  def repo!(opts \\ []) do
+    with nil <- Keyword.get(opts, :repo, repo()) do
+      raise ArgumentError, """
+      EctoShorts must be configured with a repo.
+
+      To fix this error you can do one of the following:
+
+      1. Configure the repo:
+
+      ```
+      config :ecto_shorts, :repo, YourApp.Repo
+      ```
+
+      2. Pass in the `:repo` option:
+
+      ```
+      [repo: YourApp.Repo]
+      ```
+      """
+    end
+  end
+
+  @doc """
+  Returns a `Ecto.Repo` module.
+
+  This function attempts to retrieve a repo from the `:replica` option
+  and will fallback to returning the value from the `:repo` option or
+  the configured repo if the option `:replica` is not set.
+
+  Raises if no repo is found.
+
+  ### Examples
+
+      iex> EctoShorts.Config.replica!()
+      EctoShorts.Support.Repo
+
+      iex> EctoShorts.Config.replica!(replica: YourApp.Repo.Replica)
+      YourApp.Repo.Replica
+  """
+  @spec replica!(keyword()) :: Ecto.Repo.t()
+  @spec replica! :: Ecto.Repo.t()
+  def replica!(opts \\ []) do
+    with nil <- Keyword.get(opts, :replica, replica()) do
+      repo!(opts)
+    end
   end
 end

--- a/lib/ecto_shorts/config.ex
+++ b/lib/ecto_shorts/config.ex
@@ -33,7 +33,8 @@ defmodule EctoShorts.Config do
   @doc """
   Returns a `Ecto.Repo` module.
 
-  Raises if the repo is not configured and the option `:repo` is not set.
+  Raises if the key `:repo` is not specified in configuration
+  and the option `:repo` is not specified at runtime.
 
   ### Examples
 
@@ -44,26 +45,29 @@ defmodule EctoShorts.Config do
       YourApp.Repo
   """
   @doc since: "2.5.0"
-  @spec repo!(keyword()) :: Ecto.Repo.t()
+  @spec repo!(opts :: keyword()) :: Ecto.Repo.t()
   @spec repo! :: Ecto.Repo.t()
   def repo!(opts \\ []) do
     with nil <- Keyword.get(opts, :repo, repo()) do
       raise ArgumentError, """
-      EctoShorts must be configured with a repo.
+      EctoShorts repo not configured!
 
-      To fix this error you can do one of the following:
+      Expected one of the following:
 
-      1. Configure the repo:
+      * The option `:repo` is specified at runtime.
 
-      ```
-      config :ecto_shorts, :repo, YourApp.Repo
-      ```
+        ```
+        EctoShorts.Actions.all(YourApp.Schema, %{id: [1, 2, 3]}, repo: YourApp.Repo)
+        ```
 
-      2. Pass in the `:repo` option:
+      * The option `:repo` is set in configuration.
 
-      ```
-      [repo: YourApp.Repo]
-      ```
+        ```
+        # config.exs
+        import Config
+
+        config :ecto_shorts, :repo, YourApp.Repo.Replica
+        ```
       """
     end
   end
@@ -71,11 +75,9 @@ defmodule EctoShorts.Config do
   @doc """
   Returns a `Ecto.Repo` module.
 
-  This function attempts to retrieve a repo from the `:replica` option
-  and will fallback to returning the value from the `:repo` option or
-  the configured repo if the option `:replica` is not set.
-
-  Raises if no repo is found.
+  Raises if the key `:replica` and `:repo` is not specified in
+  configuration and the option `:replica` and `:repo` is not
+  specified at runtime.
 
   ### Examples
 
@@ -86,11 +88,46 @@ defmodule EctoShorts.Config do
       YourApp.Repo.Replica
   """
   @doc since: "2.5.0"
-  @spec replica!(keyword()) :: Ecto.Repo.t()
+  @spec replica!(opts :: keyword()) :: Ecto.Repo.t()
   @spec replica! :: Ecto.Repo.t()
   def replica!(opts \\ []) do
-    with nil <- Keyword.get(opts, :replica, replica()) do
-      repo!(opts)
+    with nil <- Keyword.get(opts, :replica, replica()),
+      nil <- Keyword.get(opts, :repo, repo()) do
+      raise ArgumentError, """
+      EctoShorts replica and repo not configured!
+
+      Expected one of the following:
+
+      * The option `:replica` is specified at runtime.
+
+        ```
+        EctoShorts.Actions.all(YourApp.Schema, %{id: [1, 2, 3]}, replica: YourApp.Repo)
+        ```
+
+      * The option `:replica` is set in configuration.
+
+        ```
+        # config.exs
+        import Config
+
+        config :ecto_shorts, :replica, YourApp.Repo.Replica
+        ```
+
+      * The option `:repo` is specified at runtime.
+
+        ```
+        EctoShorts.Actions.all(YourApp.Schema, %{id: [1, 2, 3]}, repo: YourApp.Repo)
+        ```
+
+      * The option `:repo` is set in configuration.
+
+        ```
+        # config.exs
+        import Config
+
+        config :ecto_shorts, :repo, YourApp.Repo.Replica
+        ```
+      """
     end
   end
 end

--- a/lib/ecto_shorts/config.ex
+++ b/lib/ecto_shorts/config.ex
@@ -24,6 +24,7 @@ defmodule EctoShorts.Config do
       iex> EctoShorts.Config.replica()
       nil
   """
+  @doc since: "2.5.0"
   @spec replica :: Ecto.Repo.t() | nil
   def replica do
     Application.get_env(@app, :replica)
@@ -42,6 +43,7 @@ defmodule EctoShorts.Config do
       iex> EctoShorts.Config.repo!(repo: YourApp.Repo)
       YourApp.Repo
   """
+  @doc since: "2.5.0"
   @spec repo!(keyword()) :: Ecto.Repo.t()
   @spec repo! :: Ecto.Repo.t()
   def repo!(opts \\ []) do
@@ -83,6 +85,7 @@ defmodule EctoShorts.Config do
       iex> EctoShorts.Config.replica!(replica: YourApp.Repo.Replica)
       YourApp.Repo.Replica
   """
+  @doc since: "2.5.0"
   @spec replica!(keyword()) :: Ecto.Repo.t()
   @spec replica! :: Ecto.Repo.t()
   def replica!(opts \\ []) do

--- a/test/ecto_shorts/actions_abstract_schema_test.exs
+++ b/test/ecto_shorts/actions_abstract_schema_test.exs
@@ -12,14 +12,14 @@ defmodule EctoShorts.ActionsAbstractSchemaTest do
     UserAvatar
   }
 
-  test "raises if repo not configured" do
-    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
+  test "raise when :repo not set in option and configuration" do
+    assert_raise ArgumentError, ~r|EctoShorts repo not configured!|, fn ->
       Actions.create({"file_info_user_avatars", FileInfo}, %{}, repo: nil)
     end
   end
 
-  test "raises if repo not configured for replica" do
-    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
+  test "raise when :repo and :replica not set in option and configuration" do
+    assert_raise ArgumentError, ~r|EctoShorts replica and repo not configured!|, fn ->
       Actions.all({"file_info_user_avatars", FileInfo}, %{}, repo: nil, replica: nil)
     end
   end

--- a/test/ecto_shorts/actions_abstract_schema_test.exs
+++ b/test/ecto_shorts/actions_abstract_schema_test.exs
@@ -13,14 +13,14 @@ defmodule EctoShorts.ActionsAbstractSchemaTest do
   }
 
   test "raises if repo not configured" do
-    assert_raise ArgumentError, ~r|ecto shorts must be configured with a repo|, fn ->
+    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
       Actions.create({"file_info_user_avatars", FileInfo}, %{}, repo: nil)
     end
   end
 
   test "raises if repo not configured for replica" do
-    assert_raise ArgumentError, ~r|ecto shorts must be configured with a repo|, fn ->
-      Actions.all({"file_info_user_avatars", FileInfo}, %{}, repo: nil)
+    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
+      Actions.all({"file_info_user_avatars", FileInfo}, %{}, repo: nil, replica: nil)
     end
   end
 

--- a/test/ecto_shorts/actions_test.exs
+++ b/test/ecto_shorts/actions_test.exs
@@ -13,14 +13,14 @@ defmodule EctoShorts.ActionsTest do
   }
 
   test "raises if repo not configured" do
-    assert_raise ArgumentError, ~r|ecto shorts must be configured with a repo|, fn ->
+    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
       Actions.create(Comment, %{}, repo: nil)
     end
   end
 
   test "raises if repo not configured for replica" do
-    assert_raise ArgumentError, ~r|ecto shorts must be configured with a repo|, fn ->
-      Actions.all(Comment, %{}, repo: nil)
+    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
+      Actions.all(Comment, %{}, repo: nil, replica: nil)
     end
   end
 

--- a/test/ecto_shorts/actions_test.exs
+++ b/test/ecto_shorts/actions_test.exs
@@ -12,14 +12,14 @@ defmodule EctoShorts.ActionsTest do
     Post
   }
 
-  test "raises if repo not configured" do
-    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
+  test "raise when :repo not set in option and configuration" do
+    assert_raise ArgumentError, ~r|EctoShorts repo not configured!|, fn ->
       Actions.create(Comment, %{}, repo: nil)
     end
   end
 
-  test "raises if repo not configured for replica" do
-    assert_raise ArgumentError, ~r|EctoShorts must be configured with a repo|, fn ->
+  test "raise when :repo and :replica not set in option and configuration" do
+    assert_raise ArgumentError, ~r|EctoShorts replica and repo not configured!|, fn ->
       Actions.all(Comment, %{}, repo: nil, replica: nil)
     end
   end

--- a/test/ecto_shorts/config_test.exs
+++ b/test/ecto_shorts/config_test.exs
@@ -1,0 +1,4 @@
+defmodule EctoShorts.ConfigTest do
+  use ExUnit.Case, async: true
+  doctest EctoShorts.Config
+end


### PR DESCRIPTION
- Moves the logic for the repo out of `EctoShorts.Actions` and makes it a public function in `EctoShorts.Config` which provides a centralized location for this logic to be used by different parts of the api.
- Adds `:replica` configuration option