### PR TITLE
refactor query builder api *breaking change*

### DIFF
--- a/lib/ecto_shorts/query_builder.ex
+++ b/lib/ecto_shorts/query_builder.ex
@@ -2,6 +2,7 @@ defmodule EctoShorts.QueryBuilder do
   @moduledoc """
   Specifies the query builder API required from adapters.
   """
+  @moduledoc since: "2.5.0"
 
   @type adapter :: module()
   @type filter_key :: atom()

--- a/lib/ecto_shorts/query_builder/common.ex
+++ b/lib/ecto_shorts/query_builder/common.ex
@@ -3,6 +3,7 @@ defmodule EctoShorts.QueryBuilder.Common do
   This module contains query building parts for common things such
   as preload, start/end date and others
   """
+  @moduledoc since: "2.5.0"
   import Logger, only: [debug: 1]
 
   alias EctoShorts.{

--- a/lib/ecto_shorts/query_builder/schema.ex
+++ b/lib/ecto_shorts/query_builder/schema.ex
@@ -4,35 +4,77 @@ defmodule EctoShorts.QueryBuilder.Schema do
   when passed a query it can pull the schema from it and attempt
   to filter on any natural field
   """
-  alias EctoShorts.QueryBuilder
+  alias EctoShorts.{
+    QueryBuilder,
+    QueryHelpers
+  }
+
   alias EctoShorts.QueryBuilder.Schema.ComparisonFilter
 
-  require Logger
+  alias Ecto.Query
   require Ecto.Query
+
+  require Logger
+
+  @type filter_key :: atom()
+  @type filter_value :: any()
+  @type filters :: list(atom())
+  @type source :: binary()
+  @type query :: Ecto.Query.t()
+  @type queryable :: Ecto.Queryable.t()
+  @type source_queryable :: {source(), queryable()}
 
   @behaviour QueryBuilder
 
-  @impl QueryBuilder
-  def create_schema_filter({filter_field, val}, query) do
-    create_schema_filter(
-      {filter_field, val},
-      QueryBuilder.query_schema(query),
-      query
-    )
+  @impl true
+  @doc """
+  Implementation for `c:EctoShorts.QueryBuilder.create_schema_filter/3`.
+
+  ### Examples
+
+      iex> EctoShorts.QueryBuilder.Schema.create_schema_filter(EctoShorts.Support.Schemas.Post, :comments, %{id: 1})
+  """
+  @spec create_schema_filter(
+    query :: query(),
+    filter_key :: filter_key(),
+    filter_value :: filter_value()
+  ) :: query()
+  def create_schema_filter(query, filter_key, filter_value) do
+    queryable = QueryHelpers.get_queryable(query)
+
+    create_schema_filter(queryable, query, filter_key, filter_value)
   end
 
-  def create_schema_filter({filter_field, val}, schema, query) do
+  @doc """
+  Builds an ecto query for the given `Ecto.Schema`.
+
+  ### Examples
+
+      iex> EctoShorts.QueryBuilder.Schema.create_schema_filter(
+      ...>   EctoShorts.Support.Schemas.Post,
+      ...>   Ecto.Query.from(EctoShorts.Support.Schemas.Post),
+      ...>   :comments,
+      ...>   %{id: 1}
+      ...> )
+  """
+  @spec create_schema_filter(
+    queryable :: queryable(),
+    query :: query(),
+    filter_key :: filter_key(),
+    filter_value :: filter_value()
+  ) :: query()
+  def create_schema_filter(queryable, query, filter_key, filter_value) do
     cond do
-      filter_field in schema.__schema__(:query_fields) ->
-        create_schema_query_field_filter(query, schema, filter_field, val)
+      filter_key in queryable.__schema__(:query_fields) ->
+        create_schema_query_field_filter(queryable, query, filter_key, filter_value)
 
-      filter_field in schema.__schema__(:associations) ->
-        relational_schema = ecto_association_queryable!(schema, filter_field)
+      filter_key in queryable.__schema__(:associations) ->
+        assoc_schema = ecto_association_queryable!(queryable, filter_key)
 
-        create_schema_assocation_filter(query, filter_field, val, schema, relational_schema)
+        create_schema_assocation_filter(queryable, query, filter_key, filter_value, assoc_schema)
 
       true ->
-        Logger.debug("[EctoShorts] #{Atom.to_string(filter_field)} is neither a field nor has a valid association for #{schema.__schema__(:source)} where filter")
+        Logger.debug("[EctoShorts] #{Atom.to_string(filter_key)} is neither a field nor has a valid association for #{queryable.__schema__(:source)} where filter")
 
         query
     end
@@ -51,28 +93,29 @@ defmodule EctoShorts.QueryBuilder.Schema do
     end
   end
 
-  defp create_schema_query_field_filter(query, schema, filter_field, val) do
-    case schema.__schema__(:type, filter_field) do
+  defp create_schema_query_field_filter(queryable, query, filter_key, filter_value) do
+    case queryable.__schema__(:type, filter_key) do
       {:array, _} ->
-        ComparisonFilter.build_array(query, schema.__schema__(:field_source, filter_field), val)
+        ComparisonFilter.build_array(query, queryable.__schema__(:field_source, filter_key), filter_value)
 
       _ ->
-        ComparisonFilter.build(query, schema.__schema__(:field_source, filter_field), val)
+        ComparisonFilter.build(query, queryable.__schema__(:field_source, filter_key), filter_value)
 
     end
   end
 
-  defp create_schema_assocation_filter(query, filter_field, val, _schema, relational_schema) do
-    binding_alias = :"ecto_shorts_#{filter_field}"
+  defp create_schema_assocation_filter(_queryable, query, filter_key, filter_value, assoc_schema) do
+    binding_alias = :"ecto_shorts_#{filter_key}"
 
     query
-    |> Ecto.Query.with_named_binding(binding_alias, fn query, binding_alias ->
-      Ecto.Query.join(
+    |> Query.with_named_binding(binding_alias, fn query, binding_alias ->
+      Query.join(
         query,
         :inner,
         [scm],
-        assoc in assoc(scm, ^filter_field), as: ^binding_alias)
+        assoc in assoc(scm, ^filter_key), as: ^binding_alias
+      )
     end)
-    |> ComparisonFilter.build_relational(binding_alias, val, relational_schema)
+    |> ComparisonFilter.build_relational(binding_alias, filter_value, assoc_schema)
   end
 end

--- a/lib/ecto_shorts/query_builder/schema.ex
+++ b/lib/ecto_shorts/query_builder/schema.ex
@@ -4,6 +4,8 @@ defmodule EctoShorts.QueryBuilder.Schema do
   when passed a query it can pull the schema from it and attempt
   to filter on any natural field
   """
+  @moduledoc since: "2.5.0"
+
   alias EctoShorts.{
     QueryBuilder,
     QueryHelpers

--- a/lib/ecto_shorts/query_builder/schema/comparison_filter.ex
+++ b/lib/ecto_shorts/query_builder/schema/comparison_filter.ex
@@ -5,152 +5,154 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
   # values which then forces us to define two separate versions
 
   require Logger
-  import Ecto.Query, only: [where: 3]
+
+  alias Ecto.Query
+  require Ecto.Query
 
   # Non relational fields
-  def build(query, filter_field, val) when is_list(val) do
-    where(query, [scm], field(scm, ^filter_field) in ^val)
+  def build(query, filter_key, filter_value) when is_list(filter_value) do
+    Query.where(query, [scm], field(scm, ^filter_key) in ^filter_value)
   end
 
-  def build(query, filter_field, %NaiveDateTime{} = val) do
-    where(query, [scm], field(scm, ^filter_field) == ^val)
+  def build(query, filter_key, %NaiveDateTime{} = filter_value) do
+    Query.where(query, [scm], field(scm, ^filter_key) == ^filter_value)
   end
 
-  def build(query, filter_field, %DateTime{} = val) do
-    where(query, [scm], field(scm, ^filter_field) == ^val)
+  def build(query, filter_key, %DateTime{} = filter_value) do
+    Query.where(query, [scm], field(scm, ^filter_key) == ^filter_value)
   end
 
-  def build(_query, _filter_field, nil) do
+  def build(_query, _filter_key, nil) do
     raise ArgumentError, message: "comparison with nil is forbidden as it is unsafe. If you want to check if a value is nil, use %{==: nil} or %{!=: nil} instead"
   end
 
-  def build(query, filter_field, filters) when is_map(filters) do
+  def build(query, filter_key, filters) when is_map(filters) do
     Enum.reduce(filters, query, fn ({filter_type, value}, query) ->
-      build_schema_field_filters(query, nil, filter_field, filter_type, value)
+      build_schema_field_filters(query, nil, filter_key, filter_type, value)
     end)
   end
 
-  def build(query, filter_field, {:lower, val}) do
-    where(query, [scm], fragment("lower(?)", field(scm, ^filter_field)) == ^val)
+  def build(query, filter_key, {:lower, filter_value}) do
+    Query.where(query, [scm], fragment("lower(?)", field(scm, ^filter_key)) == ^filter_value)
   end
 
-  def build(query, filter_field, {:upper, val}) do
-    where(query, [scm], fragment("upper(?)", field(scm, ^filter_field)) == ^val)
+  def build(query, filter_key, {:upper, filter_value}) do
+    Query.where(query, [scm], fragment("upper(?)", field(scm, ^filter_key)) == ^filter_value)
   end
 
-  def build(query, filter_field, val) do
-    where(query, [scm], field(scm, ^filter_field) == ^val)
+  def build(query, filter_key, filter_value) do
+    Query.where(query, [scm], field(scm, ^filter_key) == ^filter_value)
   end
 
-  def build_array(query, filter_field, val) when is_list(val) do
-    where(query, [scm], field(scm, ^filter_field) == ^val)
+  def build_array(query, filter_key, filter_value) when is_list(filter_value) do
+    Query.where(query, [scm], field(scm, ^filter_key) == ^filter_value)
   end
 
-  def build_array(query, filter_field, filters) when is_map(filters) do
-    build(query, filter_field, filters)
+  def build_array(query, filter_key, filters) when is_map(filters) do
+    build(query, filter_key, filters)
   end
 
-  def build_array(query, filter_field, val) do
-    where(query, [scm], ^val in field(scm, ^filter_field))
+  def build_array(query, filter_key, filter_value) do
+    Query.where(query, [scm], ^filter_value in field(scm, ^filter_key))
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :==, nil) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :==, nil) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], is_nil(field(scm, ^filter_field)))
+      Query.where(query, [{^binding_alias, scm}], is_nil(field(scm, ^filter_key)))
     else
-      where(query, [scm], is_nil(field(scm, ^filter_field)))
+      Query.where(query, [scm], is_nil(field(scm, ^filter_key)))
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :!=, nil) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :!=, nil) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], not is_nil(field(scm, ^filter_field)))
+      Query.where(query, [{^binding_alias, scm}], not is_nil(field(scm, ^filter_key)))
     else
-      where(query, [scm], not is_nil(field(scm, ^filter_field)))
+      Query.where(query, [scm], not is_nil(field(scm, ^filter_key)))
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :!=, val) when is_list(val) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :!=, filter_value) when is_list(filter_value) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], field(scm, ^filter_field) not in ^val)
+      Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) not in ^filter_value)
     else
-      where(query, [scm], field(scm, ^filter_field) not in ^val)
+      Query.where(query, [scm], field(scm, ^filter_key) not in ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :!=, {:lower, val}) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :!=, {:lower, filter_value}) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], fragment("lower(?)", field(scm, ^filter_field)) != ^val)
+      Query.where(query, [{^binding_alias, scm}], fragment("lower(?)", field(scm, ^filter_key)) != ^filter_value)
     else
-      where(query, [scm], fragment("lower(?)", field(scm, ^filter_field)) != ^val)
+      Query.where(query, [scm], fragment("lower(?)", field(scm, ^filter_key)) != ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :!=, {:upper, val}) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :!=, {:upper, filter_value}) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], fragment("upper(?)", field(scm, ^filter_field)) != ^val)
+      Query.where(query, [{^binding_alias, scm}], fragment("upper(?)", field(scm, ^filter_key)) != ^filter_value)
     else
-      where(query, [scm], fragment("upper(?)", field(scm, ^filter_field)) != ^val)
+      Query.where(query, [scm], fragment("upper(?)", field(scm, ^filter_key)) != ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :!=, val) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :!=, filter_value) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], field(scm, ^filter_field) != ^val)
+      Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) != ^filter_value)
     else
-      where(query, [scm], field(scm, ^filter_field) != ^val)
+      Query.where(query, [scm], field(scm, ^filter_key) != ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :gt, val) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :gt, filter_value) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], field(scm, ^filter_field) > ^val)
+      Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) > ^filter_value)
     else
-      where(query, [scm], field(scm, ^filter_field) > ^val)
+      Query.where(query, [scm], field(scm, ^filter_key) > ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :lt, val) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :lt, filter_value) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], field(scm, ^filter_field) < ^val)
+      Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) < ^filter_value)
     else
-      where(query, [scm], field(scm, ^filter_field) < ^val)
+      Query.where(query, [scm], field(scm, ^filter_key) < ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :gte, val) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :gte, filter_value) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], field(scm, ^filter_field) >= ^val)
+      Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) >= ^filter_value)
     else
-      where(query, [scm], field(scm, ^filter_field) >= ^val)
+      Query.where(query, [scm], field(scm, ^filter_key) >= ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :lte, val) do
+  defp build_schema_field_filters(query, binding_alias, filter_key, :lte, filter_value) do
     if binding_alias do
-      where(query, [{^binding_alias, scm}], field(scm, ^filter_field) <= ^val)
+      Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) <= ^filter_value)
     else
-      where(query, [scm], field(scm, ^filter_field) <= ^val)
+      Query.where(query, [scm], field(scm, ^filter_key) <= ^filter_value)
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :like, val) do
-    search_query = "%#{val}%"
+  defp build_schema_field_filters(query, binding_alias, filter_key, :like, filter_value) do
+    search_query = "%#{filter_value}%"
 
     if binding_alias do
-      where(query, [{^binding_alias, scm}], like(field(scm, ^filter_field), ^search_query))
+      Query.where(query, [{^binding_alias, scm}], like(field(scm, ^filter_key), ^search_query))
     else
-      where(query, [scm], like(field(scm, ^filter_field), ^search_query))
+      Query.where(query, [scm], like(field(scm, ^filter_key), ^search_query))
     end
   end
 
-  defp build_schema_field_filters(query, binding_alias, filter_field, :ilike, val) do
-    search_query = "%#{val}%"
+  defp build_schema_field_filters(query, binding_alias, filter_key, :ilike, filter_value) do
+    search_query = "%#{filter_value}%"
 
     if binding_alias do
-      where(query, [{^binding_alias, scm}], ilike(field(scm, ^filter_field), ^search_query))
+      Query.where(query, [{^binding_alias, scm}], ilike(field(scm, ^filter_key), ^search_query))
     else
-      where(query, [scm], ilike(field(scm, ^filter_field), ^search_query))
+      Query.where(query, [scm], ilike(field(scm, ^filter_key), ^search_query))
     end
   end
 
@@ -170,16 +172,16 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     raise ArgumentError, message: "must provide a map for associations to filter on\ngiven #{inspect value}"
   end
 
-  defp build_relational_filter(query, binding_alias, filter_field, val, _relational_schema) when is_list(val) do
-    where(query, [{^binding_alias, scm}], field(scm, ^filter_field) in ^val)
+  defp build_relational_filter(query, binding_alias, filter_key, filter_value, _relational_schema) when is_list(filter_value) do
+    Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) in ^filter_value)
   end
 
-  defp build_relational_filter(query, binding_alias, filter_field, %NaiveDateTime{} = val, _relational_schema) do
-    where(query, [{^binding_alias, scm}], field(scm, ^filter_field) == ^val)
+  defp build_relational_filter(query, binding_alias, filter_key, %NaiveDateTime{} = filter_value, _relational_schema) do
+    Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) == ^filter_value)
   end
 
-  defp build_relational_filter(query, binding_alias, filter_field, %DateTime{} = val, _relational_schema) do
-    where(query, [{^binding_alias, scm}], field(scm, ^filter_field) == ^val)
+  defp build_relational_filter(query, binding_alias, filter_key, %DateTime{} = filter_value, _relational_schema) do
+    Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) == ^filter_value)
   end
 
   defp build_relational_filter(query, binding_alias, field_key, filters, relational_schema) when is_map(filters) do
@@ -209,8 +211,8 @@ defmodule EctoShorts.QueryBuilder.Schema.ComparisonFilter do
     end
   end
 
-  defp build_relational_filter(query, binding_alias, filter_field, val, _relational_schema) do
-    where(query, [{^binding_alias, scm}], field(scm, ^filter_field) == ^val)
+  defp build_relational_filter(query, binding_alias, filter_key, filter_value, _relational_schema) do
+    Query.where(query, [{^binding_alias, scm}], field(scm, ^filter_key) == ^filter_value)
   end
 
   defp ecto_association_queryable!(schema, field_key) do

--- a/test/ecto_shorts/query_builder/common_test.exs
+++ b/test/ecto_shorts/query_builder/common_test.exs
@@ -26,9 +26,9 @@ defmodule EctoShorts.QueryBuilder.CommonTest do
 
   describe "create_schema_filters: " do
     test "returns query without changes when passed {:search, term()}" do
-      expected_query = Comment
+      query = Comment
 
-      assert ^expected_query = Common.create_schema_filter({:search, %{id: 1}}, expected_query)
+      assert ^query = Common.create_schema_filter(query, :search, %{id: 1})
     end
   end
 end

--- a/test/ecto_shorts/query_builder/schema_test.exs
+++ b/test/ecto_shorts/query_builder/schema_test.exs
@@ -1,5 +1,8 @@
 defmodule EctoShorts.QueryBuilder.SchemaTest do
   use ExUnit.Case, async: true
+
+  require Ecto.Query
+
   doctest EctoShorts.QueryBuilder.Schema
 
   alias EctoShorts.QueryBuilder.Schema
@@ -7,7 +10,7 @@ defmodule EctoShorts.QueryBuilder.SchemaTest do
 
   describe "create_schema_filter: " do
     test "returns a query where record matches query field value" do
-      query = Schema.create_schema_filter({:id, 1}, Post)
+      query = Schema.create_schema_filter(Post, :id, 1)
 
       assert %Ecto.Query{
         aliases: %{},
@@ -29,7 +32,7 @@ defmodule EctoShorts.QueryBuilder.SchemaTest do
     end
 
     test "returns a query where record matches association params" do
-      query = Schema.create_schema_filter({:comments, %{id: 1}}, Post)
+      query = Schema.create_schema_filter(Post, :comments, %{id: 1})
 
       assert %Ecto.Query{
         aliases: %{
@@ -68,13 +71,13 @@ defmodule EctoShorts.QueryBuilder.SchemaTest do
     end
 
     test "returns query without changes when key is not a valid field" do
-      expected_query = Post
+      query = Post
 
-      assert ^expected_query = Schema.create_schema_filter({:invalid_association, 1}, expected_query)
+      assert ^query = Schema.create_schema_filter(query, :invalid_association, 1)
     end
 
     test "returns query that joins on has_many through association" do
-      query = Schema.create_schema_filter({:authors, %{id: 1}}, Post)
+      query = Schema.create_schema_filter(Post, :authors, %{id: 1})
 
       assert %Ecto.Query{
         aliases: %{
@@ -113,7 +116,7 @@ defmodule EctoShorts.QueryBuilder.SchemaTest do
     end
 
     test "returns query that matches on record by an array query field" do
-      query = Schema.create_schema_filter({:tags, ["tag"]}, Comment)
+      query = Schema.create_schema_filter(Comment, :tags, ["tag"])
 
       assert %Ecto.Query{
         aliases: %{},

--- a/test/ecto_shorts/query_builder_test.exs
+++ b/test/ecto_shorts/query_builder_test.exs
@@ -1,4 +1,30 @@
 defmodule EctoShorts.QueryBuilderTest do
-  use ExUnit.Case, async: true
+  use EctoShorts.DataCase
+
+  require Ecto.Query
+
   doctest EctoShorts.QueryBuilder
+
+  alias Ecto.Query
+  alias EctoShorts.QueryBuilder
+  alias EctoShorts.Support.Schemas.Comment
+  alias EctoShorts.Support.Repo
+
+  describe "create_schema_filter: " do
+    test "returns the result of the ecto query dsl" do
+      comment =
+        %Comment{}
+        |> Comment.changeset()
+        |> Repo.insert!()
+
+      comment_id = comment.id
+
+      ecto_query = Query.from(c in Comment, where: c.id == ^comment_id)
+
+      builder_query =
+        QueryBuilder.create_schema_filter(QueryBuilder.Schema, Comment, :id, comment_id)
+
+      assert Repo.one(ecto_query) === Repo.one(builder_query)
+    end
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,9 @@
 ExUnit.start()
 
+if System.get_env("CI") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 {:ok, _} = Application.ensure_all_started(:postgrex)
 
 {:ok, _} = EctoShorts.Support.Repo.start_link()
@@ -14,7 +18,3 @@ ExUnit.start()
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 5
 )
-
-if System.get_env("CI") do
-  Code.put_compiler_option(:warnings_as_errors, true)
-end


### PR DESCRIPTION
The current implementation of the `EctoShorts.QueryBuilder` api is written in a way that is specific to the internal function calls of the api. This change makes the callback function `create_schema_filter` a 3-arity function and re-arranges the order of the arguments so that the `query` is the first argument which allows these functions to be chained together.