### PR TITLE
chore: bump elixir version requirement in mix.exs to 1.13

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule EctoShorts.MixProject do
     [
       app: :ecto_shorts,
       version: "2.4.0",
-      elixir: "~> 1.11",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: "Helper tools for making ecto interactions more pleasant and shorter",


### PR DESCRIPTION
This fixes the inconsistency between the defined elixir version in `.tools-version` and the `mix.exs` file. 

In `.tools-version` the elixir version requirement is `1.13.3-otp-24` and in the `mix.exs` file it is "~> 1.11"

### Expected behaviour 

Ecto shorts compiles on elixir version 1.11.

### Current behaviour

Ecto shorts fails to compile on elixir version 1.11.

### Steps to reproduce

```bash
> asdf install erlang 23.3.4.20
> asdf install elixir 1.11

> asdf local erlang 23.3.4.20
> asdf local elixir 1.11

> mix deps.get
> mix compile
warning: the dependency :nimble_parsec requires Elixir "~> 1.12" but you are running on v1.11.4
Compiling 4 files (.ex)

== Compilation error in file lib/nimble_parsec/compiler.ex ==
** (CompileError) lib/nimble_parsec/compiler.ex:931: cannot find or invoke local _/1 inside match. Only macros can be invoked in a match and they must be defined before their invocation. Called as: _(/ / _ = range)
    (stdlib 3.14.2.3) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.14.2.3) lists.erl:1359: :lists.mapfoldl/3
    (stdlib 3.14.2.3) lists.erl:1358: :lists.mapfoldl/3
    (stdlib 3.14.2.3) lists.erl:1359: :lists.mapfoldl/3
    (elixir 1.11.4) expanding macro: Kernel.".."/2
    lib/nimble_parsec/compiler.ex:931: NimbleParsec.Compiler.newline_allowed?/1
could not compile dependency :nimble_parsec, "mix compile" failed. You can recompile this dependency with "mix deps.compile nimble_parsec", update it with "mix deps.update nimble_parsec" or clean it with "mix deps.clean nimble_parsec"
```

with this change if you run `mix compile` you now get

```
 > mix compile
** (Mix) You're trying to run :ecto_shorts on Elixir v1.11.4 but it has declared in its mix.exs file it supports only Elixir ~> 1.13
```