### PR TITLE
chore: bump version to 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Changelog
 
+#### V2.5.0
+- feat: add support for abstract queries
+- refactor: changes function `create_schema_filter` in `EctoShorts.QueryBuilder` to a 3-arity function.
+- test: add tests
+
 #### V2.4.0
 - add recursive relational filtering
 - add `%{field: %{!=: [1, 2, 3]}}` to allow `NOT IN ANY` queries
 - fix intermittent failure from `function_exported?(schema, :create_changeset, 1)`
-
 
 #### V2.3.0
 - add ability to optionally require a id or a cast/put assoc

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule EctoShorts.MixProject do
   def project do
     [
       app: :ecto_shorts,
-      version: "2.4.0",
+      version: "2.5.0",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
This is a wip. tracks the changes being made for version 2.5.0 and bumps to version in mix.exs to match.